### PR TITLE
Removing the Limit of 1000 Lines & Improving the Hungarian Notation Check

### DIFF
--- a/src/alobject.ts
+++ b/src/alobject.ts
@@ -18,7 +18,7 @@ export class alObject {
     name: string;
     lastLineNumber : number;
     constructor(theText: TextEditor) {
-        this.content = theText.document.getText(new Range(0,0,1000,1000));
+        this.content = theText.document.getText();
         this.alFunction = [];
         this.alVariable = [];
         this.alField = [];

--- a/src/alvariable.ts
+++ b/src/alvariable.ts
@@ -59,10 +59,10 @@ export class alVariable {
             hungarianOptions.alHungarianOption.forEach(hungarianOption => {
                 if ((hungarianOption.alType == this.type) && (this.isHungarianNotation == false)) {
                     if (isHungarianException(this.name) == false) {
-                        this.isHungarianNotation = (this.name.indexOf(hungarianOption.abbreviation) != -1);                        
+                        this.isHungarianNotation = (this.name.startsWith(hungarianOption.abbreviation));                        
                     }
                 }
-            });    
+            });
         }
     }
     hasWrongTempName() : boolean {


### PR DESCRIPTION
- Removing the Limit of 1000 Lines in alobject.ts (otherwise an error occurs in diagnostics.ts line 20, because myObject.alLine[i] has only 1000 entries) and
- Improving the Hungarian Notation Check (only the start of the variable will be checked now)
